### PR TITLE
ci: make main-only deploy & load-test jobs non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: � Force clean Go module cache (pre-cache)
+      - name: 🔥 Force clean Go module cache (pre-cache)
         run: |
           # Force delete cache directories to prevent tar conflicts during cache restore
           sudo rm -rf ~/go/pkg/mod ~/.cache/go-build /tmp/go-cache || true
@@ -355,7 +355,11 @@ jobs:
           echo "Cache directories force-cleaned and recreated"
         continue-on-error: true
 
-      - name: �🚀 Start services with Docker Compose
+      - name: 🚀 Start services with Docker Compose
+        # Best-effort: load testing spins up the full multi-container stack
+        # (Kafka/Zookeeper health checks are flaky in CI). A failure here must not
+        # fail the whole CI run — the load test itself is already best-effort below.
+        continue-on-error: true
         run: |
           if [ -f "docker-compose.yml" ]; then
             echo "Starting services with Docker Compose..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,27 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Job 0: Deploy preflight — verify cloud credentials before attempting any EKS
+  # deploy. GitHub does not allow the secrets context in a job-level `if:`, so we
+  # surface a boolean output here and gate the deploy jobs on it. When AWS creds
+  # are absent (a fork, or a testing/practice clone) the deploy jobs are skipped
+  # rather than failing the whole workflow.
+  preflight:
+    name: 🔎 Deploy Preflight
+    runs-on: ubuntu-latest
+    outputs:
+      has_aws: ${{ steps.check.outputs.has_aws }}
+    steps:
+      - name: 🔐 Check for AWS credentials
+        id: check
+        run: |
+          if [ -n "${{ secrets.AWS_ACCESS_KEY_ID }}" ] && [ -n "${{ secrets.EKS_CLUSTER_NAME_STAGING }}" ]; then
+            echo "has_aws=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_aws=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AWS credentials not configured — EKS deploy jobs will be skipped."
+          fi
+
   # Job 1: Build and Push Production Images
   build-production:
     name: 🔨 Build Production Images
@@ -95,9 +116,9 @@ jobs:
   deploy-staging:
     name: 🚀 Deploy to Staging
     runs-on: ubuntu-latest
-    needs: build-production
+    needs: [build-production, preflight]
     environment: staging
-    if: github.ref == 'refs/heads/main' || github.event.inputs.environment == 'staging'
+    if: (github.ref == 'refs/heads/main' || github.event.inputs.environment == 'staging') && needs.preflight.outputs.has_aws == 'true'
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
@@ -167,9 +188,9 @@ jobs:
   deploy-production:
     name: 🏭 Deploy to Production
     runs-on: ubuntu-latest
-    needs: [build-production, deploy-staging]
+    needs: [build-production, deploy-staging, preflight]
     environment: production
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production'
+    if: (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production') && needs.preflight.outputs.has_aws == 'true'
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Follow-up to #68. Two `main`-only jobs failed on every push and were the source of the auto-filed "Persistent Workflow Failures" issues (#51, #52, now closed). This makes them non-blocking so `main` CI goes — and stays — green.

## Changes

- **`deploy.yml` — skip EKS deploys when AWS creds are absent.** `deploy-staging` (and `deploy-production`) require `AWS_*` / `EKS_*` secrets that this repo doesn't have, so they failed every run. GitHub doesn't allow the `secrets` context in a job-level `if:`, so I added a small **`preflight`** job that exposes a `has_aws` boolean and gated both deploy jobs on it. With no creds they now **skip** (not fail); `build-production` still publishes images to ghcr.io.
- **`ci.yml` — load-test stack startup is best-effort.** The Load Testing job brings up the full ~13-container stack; `docker compose up --wait` fails on flaky Kafka/Zookeeper health checks. Marked that step `continue-on-error` (the load test step already was), so a flaky stack no longer reds the run.
- Fixed a mojibake emoji in the load-test cache step name.

## Effect

On a `main` push with no cloud secrets: `build-production` runs, the EKS deploy jobs skip, and the load-test job stays green even if the stack is slow to come up. No more spurious "Persistent Workflow Failures" auto-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
